### PR TITLE
Drop docker-py, use home made stuff for all things docker containers

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -61,7 +61,7 @@ and Bucky3 as well highlights of some of Bucky3 features:
 backends like InfluxDB / Prometheus offer rich data processing.
 * CollectD protocol has been dropped. Linux metrics are implemented in ~200 lines
 of Python code to provide replacement for some of the lost CollectD functionality.
-* Docker containers' metrics got implemented in under 100 lines of extra code.
+* Docker containers' metrics collection got implemented in a similar amount of code.
 * Bucky uses `setproctitle` to set human friendly names for its processes. This is a nice
 feature, but the dependency is problematic, i.e. `pip install setproctitle` needs to
 compile native code. It's been therefore removed in favor of simplicity.
@@ -97,4 +97,4 @@ everywhere, more efficient and conceptually closer to its data model.
 * Bucky imports modules at source level, Bucky3 does it dynamically. This is to avoid
 dependencies in the main process. Moreover, to improve isolation, Bucky3 delays modules
 initialization (i.e. socket / file operations) until after fork.
-* Codebase has got reduced from `~2600 loc` to `~1300 loc`
+* Codebase has got reduced from `~2600 loc` to `~1400 loc`

--- a/README.md
+++ b/README.md
@@ -72,10 +72,7 @@ modules (subprocesses). The following modules are available:
 * `statsd_server` - source module that collects metrics via extended StatsD protocol.
 * `linux_stats` - source module that collects Linux metrics via `/proc` filesystem.
 Including CPUs, system load, memory usage, filesystem usage, block devices and network interfaces activity.
-* `docker_stats` - source module that collects metrics from running docker containers. It requires
-[the docker library](https://docker-py.readthedocs.io/en/stable/) but since the module is not activated by default,
-the dependency is deliberately missing in `requirements.txt`. If you want to use it, you'll need to `pip install docker`
-or provide it otherwise.
+* `docker_stats` - source module that collects metrics from running docker containers.
 * `influxdb_client` - destination module that sends metrics to InfluxDB via
 [UDP line protocol.](https://docs.influxdata.com/influxdb/v1.3/write_protocols/line_protocol_reference/)
 It can fan out metrics to multiple hosts and automatically detect DNS changes.

--- a/bucky3/cfg.py
+++ b/bucky3/cfg.py
@@ -23,7 +23,7 @@ do the full stop/start sequence.
 # - Optional, default: 'INFO'
 # - More here: https://docs.python.org/3/library/logging.html#levels
 #   This option is in global context and will be used by all modules unless overridden.
-log_level = "INFO"
+log_level = "DEBUG"
 
 
 # log_format
@@ -169,19 +169,25 @@ linuxstats = dict(
 )
 
 
-# This module requires 'docker' package, i.e. `pip3 install docker` so it is disabled
-# in the default config. Set "module_inactive=False" (or remove the line) to enable it.
+# This module only works on linux as it uses /proc & /sys to collect containers' metrics.
+# Set "module_inactive=False" (or remove the line) to enable it.
 dockerstats = dict(
     module_type="docker_stats",
-    module_inactive=True,
+    module_inactive=False,
 
     # api_version
     # - str, defines the docker API version to use (not the same as Docker version)
-    # - Optional, default: None
-    # - More here: https://docker-py.readthedocs.io/en/stable/api.html
-    #   The default will auto-negotiate the protocol. You may need to specify this param
-    #   when using old Docker installations, see "docker version | grep API"
+    # - Optional, default: '1.22'
+    # - More here: https://docs.docker.com/engine/api/v1.32/#section/Versioning
+    #   Note that a newer docker daemon will likely handle older API calls, but the reverse
+    #   will fail. See "docker version | grep API".
     # - Example: api_version = "1.22"
+
+    # docker_socket
+    # - str, unix socket for docker
+    # - Optional, default: '/var/run/docker.sock'
+    # - Note that this module can only use local unix sockets for docker API calls.
+    # - Example: docker_socket = '/var/run/docker.sock'
 
     # env_mapping
     # - dict of str:str

--- a/bucky3/cfg.py
+++ b/bucky3/cfg.py
@@ -23,7 +23,7 @@ do the full stop/start sequence.
 # - Optional, default: 'INFO'
 # - More here: https://docs.python.org/3/library/logging.html#levels
 #   This option is in global context and will be used by all modules unless overridden.
-log_level = "DEBUG"
+log_level = "INFO"
 
 
 # log_format
@@ -173,7 +173,7 @@ linuxstats = dict(
 # Set "module_inactive=False" (or remove the line) to enable it.
 dockerstats = dict(
     module_type="docker_stats",
-    module_inactive=False,
+    module_inactive=True,
 
     # api_version
     # - str, defines the docker API version to use (not the same as Docker version)

--- a/bucky3/dockerstats.py
+++ b/bucky3/dockerstats.py
@@ -1,12 +1,54 @@
 
+"""
+We need meta info (names, labels, etc) about the containers as well as their resource
+consumption. Docker-py has all necessary calls, but the low level stats call itself:
+   docker-py.readthedocs.io/en/stable/api.html#docker.api.container.ContainerApiMixin.stats
+is slow and unpredictable at that. It can take anything from 1 to 3 secs to collect
+stats for one container. For many containers and short flush_intervals we got a problem.
+The call can be parallelized but that leads to clunky multithreaded implementation that
+scales only this much (say, 30 threads could handle 100 containers for flush_interval=10).
+
+Hence this hybrid implementation. It extracts the resources usage from /sys & /proc but
+gets the meta info via docker API calls (those used are fast though). Consequently:
+- it only works with local docker (because it uses unix socket)
+- it only works locally on linux (because it uses /proc & /sys)
+- it is single threaded and fast, metrics for 100 containers are collected in a split of sec
+- it has no external dependencies, vanilla Python3
+- it is vulnerable to future changes in docker API as well as changes in /sys layout
+"""
 
 import re
-import docker
-import requests.exceptions
+import json
+import socket
+import http.client
 import bucky3.module as module
 
 
-class DockerStatsCollector(module.MetricsSrcProcess):
+class DockerClient(http.client.HTTPConnection):
+    def __init__(self, docker_socket, api_version):
+        super().__init__(docker_socket)
+        self.api_version = api_version
+
+    def connect(self):
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.sock.connect(self.host)
+
+    def _get_json(self, url):
+        url = '/v' + self.api_version + url
+        self.request('GET', url)
+        resp = self.getresponse()
+        if resp.status != 200:
+            raise ConnectionError('Docker error code {} for {}'.format(resp.status, url))
+        return json.loads(resp.read().decode('utf-8'))
+
+    def list_containers(self):
+        return self._get_json('/containers/json')
+
+    def inspect_container(self, container_id):
+        return self._get_json('/containers/' + str(container_id) + '/json?size=true')
+
+
+class DockerStatsCollector(module.MetricsSrcProcess, module.ProcfsReader):
     def __init__(self, *args):
         super().__init__(*args)
         # See the statsd metadata matching regexp.
@@ -14,63 +56,54 @@ class DockerStatsCollector(module.MetricsSrcProcess):
 
     def init_config(self):
         super().init_config()
-        api_version = self.cfg.get('api_version')
+        self.api_version = self.cfg.get('api_version', '1.22')
+        self.docker_socket = self.cfg.get('docker_socket', '/var/run/docker.sock')
         self.env_mapping = self.cfg.get('env_mapping')
-        self.docker_client = docker.client.from_env(version=api_version)
+        self.system_memory = dict(self.read_memory())['total_bytes']
 
-    def read_df_stats(self, timestamp, container_metadata, total_size, rw_size):
-        docker_df_stats = {
-            'total_bytes': int(total_size),
-            'used_bytes': int(rw_size)
+    def read_df_stats(self, buffer, container_id, timestamp, container_metadata, inspect_info):
+        df_stats = {
+            'total_bytes': int(inspect_info['SizeRootFs']),
+            'used_bytes': int(inspect_info.get('SizeRw', 0)),
         }
-        self.buffer.append(("docker_filesystem", docker_df_stats, timestamp, container_metadata))
+        buffer.append(("docker_filesystem", df_stats, timestamp, container_metadata))
 
-    def read_cpu_stats(self, timestamp, container_metadata, stats, host_config):
-        # For some reason, we get an occasional KeyError for percpu_usage, hence the extra check.
-        if 'percpu_usage' not in stats:
-            return
-        cpu_stats = stats['percpu_usage']
-        # Docker reports CPU counters in nanosecs but quota/period in microsecs, here we make sure we send out
-        # all CPU metrics in nanosecs - that differs from linuxstats module CPU counters that are in USER_HZ.
-        limit_ps = host_config.get('NanoCpus', 0)
-        if not limit_ps:
-            cpu_period = host_config.get('CpuPeriod', 0) or 1000000
-            cpu_quota = host_config.get('CpuQuota', 0)
-            if not cpu_quota:
-                cpu_quota = cpu_period * len(cpu_stats)
-            limit_ps = round(1000000000 * cpu_quota / cpu_period)
-        self.buffer.append(("docker_cpu", {'limit_ps': limit_ps}, timestamp, container_metadata.copy()))
-        for k, v in enumerate(cpu_stats):
-            metadata = container_metadata.copy()
-            metadata.update(name=k)
-            self.buffer.append(("docker_cpu", {'usage': int(v)}, timestamp, metadata))
-
-    def read_interface_stats(self, timestamp, container_metadata, stats):
-        if not stats:
-            # This can happen if i.e. the container was started with --network="host"
-            return
-        keys = (
-            'rx_bytes', 'rx_packets', 'rx_errors', 'rx_dropped',
-            'tx_bytes', 'tx_packets', 'tx_errors', 'tx_dropped'
-        )
-        for k, v in stats.items():
-            metadata = container_metadata.copy()
-            metadata.update(name=k)
-            docker_interface_stats = {k: int(v[k]) for k in keys}
-            self.buffer.append(("docker_interface", docker_interface_stats, timestamp, metadata))
-
-    def read_memory_stats(self, timestamp, container_metadata, stats):
-        self.buffer.append(("docker_memory", {
-            'used_bytes': int(stats['usage']),
-            'limit_bytes': int(stats['limit']),
-        }, timestamp, container_metadata))
-
-    def get_container_info(self, container):
-        container_id = container['Id']
-        inspect_info = self.docker_client.api.inspect_container(container_id)
-        inspect_config = inspect_info['Config']
+    def read_cpu_stats(self, buffer, container_id, timestamp, container_metadata, inspect_info):
         host_config = inspect_info['HostConfig']
+        with open('/sys/fs/cgroup/cpu/docker/' + container_id + '/cpuacct.usage_percpu') as f:
+            cpu_tokens = f.read().strip().split()
+            for k, v in enumerate(cpu_tokens):
+                metadata = container_metadata.copy()
+                metadata.update(name='cpu' + str(k))
+                buffer.append(("docker_cpu", {'usage': int(v)}, timestamp, metadata))
+            # Docker reports CPU counters in nanosecs but quota/period in microsecs, here we make sure we send out
+            # all CPU metrics in nanosecs - that differs from linuxstats module CPU counters that are in USER_HZ.
+            limit_ps = host_config.get('NanoCpus', 0)
+            if not limit_ps:
+                cpu_period = host_config.get('CpuPeriod', 0) or 1000000
+                cpu_quota = host_config.get('CpuQuota', 0)
+                if not cpu_quota:
+                    cpu_quota = cpu_period * len(cpu_tokens)
+                limit_ps = round(1000000000 * cpu_quota / cpu_period)
+            buffer.append(("docker_cpu", {'limit_ps': limit_ps}, timestamp, container_metadata.copy()))
 
+    def read_interface_stats(self, buffer, container_id, timestamp, container_metadata, inspect_info):
+        root_pid = inspect_info['State']['Pid']
+        for interface_name, interface_stats in self.read_interfaces('/proc/' + str(root_pid) + '/net/dev'):
+            metadata = container_metadata.copy()
+            metadata.update(name=interface_name)
+            buffer.append(("docker_interface", interface_stats, timestamp, metadata))
+
+    def read_memory_stats(self, buffer, container_id, timestamp, container_metadata, inspect_info):
+        host_config = inspect_info['HostConfig']
+        with open('/sys/fs/cgroup/memory/docker/' + container_id + '/memory.usage_in_bytes') as f:
+            buffer.append(("docker_memory", {
+                'used_bytes': int(f.read().strip()),
+                'limit_bytes': int(host_config.get('Memory') or self.system_memory),
+            }, timestamp, container_metadata))
+
+    def extract_metadata(self, container_id, container_info, inspect_info):
+        inspect_config = inspect_info['Config']
         container_metadata = {}
         if self.env_mapping:
             for l in inspect_config.get('Env', []):
@@ -79,29 +112,37 @@ class DockerStatsCollector(module.MetricsSrcProcess):
                     env_name, env_value = m.group(1), m.group(2)
                     if env_name in self.env_mapping:
                         container_metadata[self.env_mapping[env_name]] = env_value
-        if container.get('Names'):
-            container_metadata['docker_name'] = container['Names'][0]
+        if container_info.get('Names'):
+            container_metadata['docker_name'] = container_info['Names'][0]
         container_metadata.update(inspect_config.get('Labels', {}))
         container_metadata['docker_id'] = container_id[:12]
-        return container_id, container_metadata, host_config
+        return container_metadata
 
     def flush(self, system_timestamp):
+        timestamp = system_timestamp if self.add_timestamps else None
+        docker_client = None
         try:
-            timestamp = system_timestamp if self.add_timestamps else None
-            for i, container in enumerate(self.docker_client.api.containers(size=True)):
-                if container.get('State') == 'running' or container.get('Status', '').startswith('Up'):
-                    container_id, container_metadata, host_config = self.get_container_info(container)
-                    stats_info = self.docker_client.api.stats(container_id, decode=True, stream=False)
-                    self.read_df_stats(timestamp, container_metadata, int(container['SizeRootFs']), int(container.get('SizeRw', 0)))
-                    self.read_cpu_stats(timestamp, container_metadata, stats_info['cpu_stats']['cpu_usage'], host_config)
-                    self.read_memory_stats(timestamp, container_metadata, stats_info['memory_stats'])
-                    self.read_interface_stats(timestamp, container_metadata, stats_info.get('networks'))
+            self.log.debug('Starting containers scan')
+            docker_client = DockerClient(self.docker_socket, self.api_version)
+            for container_info in sorted(docker_client.list_containers(), key=lambda v: v.get('Id')):
+                try:
+                    buffer = []
+                    container_id = container_info['Id']
+                    inspect_info = docker_client.inspect_container(container_id)
+                    container_metadata = self.extract_metadata(container_id, container_info, inspect_info)
+                    self.read_df_stats(buffer, container_id, timestamp, container_metadata, inspect_info)
+                    self.read_cpu_stats(buffer, container_id, timestamp, container_metadata, inspect_info)
+                    self.read_memory_stats(buffer, container_id, timestamp, container_metadata, inspect_info)
+                    self.read_interface_stats(buffer, container_id, timestamp, container_metadata, inspect_info)
+                    self.buffer.extend(buffer)
+                except FileNotFoundError:
+                    pass
+            self.log.debug('Finished containers scan')
             return super().flush(system_timestamp)
-        except requests.exceptions.ConnectionError:
-            self.log.info("Docker connection error, is docker running?")
+        except (ConnectionError, FileNotFoundError):
+            self.log.exception("Docker error, is it running?")
             super().flush(system_timestamp)
             return False
-        except ValueError:
-            self.log.exception("Docker error")
-            super().flush(system_timestamp)
-            return False
+        finally:
+            if docker_client:
+                docker_client.close()


### PR DESCRIPTION
docker-py (or more precisely docker daemon itself) is slow and flaky
at returning container resources consumption.
This is a rewrite using direct access to /sys & /proc for it.
There are still some docker API calls needed for met info,
but they are very simple and therefore were implemented
with Python vanilla http.client.